### PR TITLE
Relax Ruby requirement to 3.0 and optimize CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4']
-        gemfile:
-          - gemfiles/7.0.gemfile
-          - gemfiles/7.1.gemfile
-          - gemfiles/7.2.gemfile
-          - gemfiles/8.0.gemfile
-          - gemfiles/8.1.gemfile
+        include:
+          - ruby: '3.0'
+            gemfile: gemfiles/7.0.gemfile
+          - ruby: '3.1'
+            gemfile: gemfiles/7.1.gemfile
+          - ruby: '3.2'
+            gemfile: gemfiles/7.2.gemfile
+          - ruby: '3.3'
+            gemfile: gemfiles/8.0.gemfile
+          - ruby: '3.4'
+            gemfile: gemfiles/7.2.gemfile
+          - ruby: '3.4'
+            gemfile: gemfiles/8.0.gemfile
+          - ruby: '3.4'
+            gemfile: gemfiles/8.1.gemfile
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.0
   Include:
     - "**/*.gemspec"
     - "**/*.podspec"

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.post_install_message = File.read("UPGRADING") if File.exist?("UPGRADING")
 
   s.requirements << "ImageMagick"
-  s.required_ruby_version = ">= 3.2.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.add_dependency("activemodel", ">= 7.0.0")
   s.add_dependency("activesupport", ">= 7.0.0")


### PR DESCRIPTION
- Lower minimum Ruby version from 3.2 to 3.0 for Rails 7.0 compatibility
- Replace full CI matrix with targeted Ruby/Rails version pairs
- Add Ruby 3.4 coverage for Rails 7.2, 8.0, and 8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified CI workflow matrix to explicit Ruby/gemfile combinations for more predictable test runs.

* **Chores**
  * Lowered minimum supported Ruby to 3.0.0.
  * Updated linting configuration target to Ruby 3.0.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->