### PR TITLE
Fix repeated animation probing in Thumbnail + Resolve global backend at processing time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+8.0.7 (2026-06-11)
+
+* Performance: Fix repeated animation probing in Thumbnail.
+* Bugfix: The global backend (Paperclip.options[:backend]) is now read at processing time instead of
+  being captured into Attachment.default_options when that hash is first built.
+
 8.0.6 (2026-05-22)
 
 * Chore: Update image_processing runtime dependency to ~> 2.0

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -36,8 +36,7 @@ module Paperclip
         validate_media_type:               true,
         adapter_options:                   { hash_digest: Digest::MD5 },
         check_validity_before_processing:  true,
-        return_file_attributes_on_destroy: false,
-        backend:                           Paperclip.options[:backend]
+        return_file_attributes_on_destroy: false
       }
     end
 

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -641,12 +641,16 @@ module Paperclip
     end
 
     def animated_source?
-      @animated_source ||= begin
+      return @animated_source if defined?(@animated_source)
+
+      @animated_source = begin
         case backend
         when :vips
-          vips_image(File.expand_path(@file.path)).get("n-pages").to_i > 1
+          vips_image(File.expand_path(@file.path), access: :sequential).get("n-pages").to_i > 1
         when :image_magick
-          identify("-format %n :file", file: File.expand_path(@file.path)).to_i > 1
+          # Limit identify to the first two frames: counting all frames with
+          # %n decodes the entire file, which is expensive for large animations.
+          identify("-format %n :file", file: "#{File.expand_path(@file.path)}[0-1]").to_i > 1
         else
           extension_indicates_animation?
         end

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Paperclip
-  VERSION = "8.0.6"
+  VERSION = "8.0.7"
 end

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -55,6 +55,14 @@ describe Paperclip::Thumbnail do
       end
     end
 
+    describe "animation detection" do
+      it "probes a non-animated source only once even though the result is false" do
+        thumb = described_class.new(@file, geometry: "50x50")
+        expect(thumb).to receive(:identify).once.and_call_original
+        3.times { expect(thumb.send(:animated_source?)).to be false }
+      end
+    end
+
     describe "per-style backend selection (integration)" do
       let(:attachment) { double("Attachment", options: {}) }
 
@@ -1441,6 +1449,12 @@ describe Paperclip::Thumbnail do
         # We want exactly 50x50
         assert_equal "50x50", output
       end
+    end
+
+    it "probes the source for animation only once" do
+      thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50")
+      expect(thumb).to receive(:identify).once.and_call_original
+      3.times { expect(thumb.send(:animated_source?)).to be true }
     end
 
     context "with a specified frame_index" do

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -24,6 +24,18 @@ describe Paperclip::Thumbnail do
         expect(processor.backend).to eq(:image_magick)
       end
 
+      it "honors a global backend set after Attachment.default_options has been memoized" do
+        Paperclip::Attachment.default_options
+        original_backend = Paperclip.options[:backend]
+        Paperclip.options[:backend] = :vips
+
+        real_attachment = Paperclip::Attachment.new(:avatar, FakeModel.new)
+        processor = described_class.new(@file, { geometry: "25x25" }, real_attachment)
+        expect(processor.backend).to eq(:vips)
+      ensure
+        Paperclip.options[:backend] = original_backend
+      end
+
       it "defaults to image_magick when backend is nil" do
         original_backend = Paperclip.options[:backend]
         Paperclip.options[:backend] = nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed backend option to be properly evaluated at processing time instead of being captured when attachment is first initialized, ensuring dynamically configured backends work as expected
- Improved thumbnail generation performance by optimizing animation frame detection to avoid redundant probing, significantly reducing computational costs when processing multiple attachments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->